### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,9 @@ by performing mathematical operations (called "compound data" in this program).
 ## Dependencies
 
 * [pandas](https://pandas.pydata.org/)
-* [python-Levenshtein](https://github.com/ztane/python-Levenshtein)
-* [fuzzywuzzy](https://github.com/seatgeek/fuzzywuzzy)
+* [rapidfuzz](https://github.com/rhasspy/rapidfuzz)
 
-The latter two are mostly used for search through display labels (place names).
+The last is mostly used for search through display labels (place names).
 
 ## Setup
 
@@ -75,8 +74,7 @@ the files from the subfolders to your data directory. If you are using Linux,
     file with geodata.
 
 5. This project depends on [pandas](https://pandas.pydata.org/),
-[python-Levenshtein](https://github.com/ztane/python-Levenshtein), and
-[fuzzywuzzy](https://github.com/seatgeek/fuzzywuzzy) Install these first. One
+ and [rapidfuzz](https://github.com/rhasspy/rapidfuzz) Install these first. One
 way to do so is by executing:
 
         $ pip3 install pandas sqlalchemy

--- a/geodata/__main__.py
+++ b/geodata/__main__.py
@@ -12,7 +12,7 @@ from tools.StateTools import StateTools
 from tools.KeyTools import KeyTools
 from tools.SummaryLevelTools import SummaryLevelTools
 
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 
 def create_data_products(args):
     '''Generate and save data products.'''

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 pandas
-python-Levenshtein
-fuzzywuzzy
+rapidfuzz==0.2.0


### PR DESCRIPTION
FuzzyWuzzy and Python-Levenshtein are both GPLv2 licensed which would force you to licence the whole project under GPLv2. I had the same problem on one of my projects and so I wrote rapidfuzz which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed and is therefor MIT Licensed aswell, so it can be used in here without forcing a License change. As a nice bonus it is fully implemented in C++ and comes with a few Algorithmic improvements making it between 5 and 100 times faster than FuzzyWuzzy.